### PR TITLE
Refactor for: relative imports and move "imports" out of function

### DIFF
--- a/peerme.py
+++ b/peerme.py
@@ -11,9 +11,11 @@ import sys
 import time
 
 from os.path import expanduser
-
-import config as peerme_config
-import peerme_db
+from peerme import config as peerme_config
+from peerme import peerme_db
+from peerme.commands.check_routing import CheckRoutingCli
+from peerme.commands.discover import DiscoverCli
+from peerme.commands.request import RequestCli
 
 # TODO: Get relative imports working
 # SystemError: Parent module '' not loaded, cannot perform relative import
@@ -22,14 +24,6 @@ import peerme_db
 #)
 
 CLICK_CONTEXT_SETTINGS = {'help_option_names': ('-h', '--help')}
-
-
-class PeermeCmd():
-    ''' Base class for all sub commands to inherit from '''
-
-    def __init__(self, main_opts):
-        ''' Store Global main arguments etc. '''
-        self.opts = main_opts
 
 
 class Options():
@@ -99,11 +93,8 @@ def main(ctx, config, debug):
 
 def add_internal_modules():
     ''' Add internal modules to main parser '''
-    from check_routing import CheckRoutingCli
     main.add_command(CheckRoutingCli().check_routing)
-    from discover import DiscoverCli
     main.add_command(DiscoverCli().discover)
-    from request import RequestCli
     main.add_command(RequestCli().pinder)
 
 

--- a/peerme/commands/check_routing.py
+++ b/peerme/commands/check_routing.py
@@ -7,7 +7,7 @@
 import click
 import logging
 
-from peerme import PeermeCmd
+from .cli_common import PeermeCmd
 
 
 class CheckRoutingCli():

--- a/peerme/commands/cli_common.py
+++ b/peerme/commands/cli_common.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+
+class PeermeCmd():
+    ''' Base class for all sub commands to inherit from '''
+
+    def __init__(self, main_opts):
+        ''' Store Global main arguments etc. '''
+        self.opts = main_opts

--- a/peerme/commands/discover.py
+++ b/peerme/commands/discover.py
@@ -8,9 +8,7 @@
 import click
 import logging
 
-# TODO(cooper): Make relative imports work
-#from . import peerme
-from peerme import PeermeCmd
+from .cli_common import PeermeCmd
 
 
 class DiscoverCli():

--- a/peerme/commands/request.py
+++ b/peerme/commands/request.py
@@ -7,7 +7,7 @@
 import click
 import logging
 
-from peerme import PeermeCmd
+from .cli_common import PeermeCmd
 
 
 class RequestCli():

--- a/peerme/peerme_db.py
+++ b/peerme/peerme_db.py
@@ -9,8 +9,9 @@ import logging
 
 import sys
 
-import peer
+from . import peer
 import aiomysql
+
 from pymysql import err as pymysql_err
 
 class PeermeDb():


### PR DESCRIPTION
1. Relative imports now work: 
2. Had to move peerme.py out of the package
3. Refactor so we can pull out imports from add_internal_module
